### PR TITLE
18 pipeline reliability resilience upgrades

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "model": "sonnet",
+  "alwaysThinkingEnabled": true,
+  "permissions": {
+    "deny": [
+      "Bash(**/.env)",
+      "Read(**/.env)",
+      "Write(**/.env)"
+    ]
+  },
+  "env": {
+    "CLAUDE_CODE_HIDE_ACCOUNT_INFO": "1"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ ruff format .
 pre-commit run --all-files
 ```
 
-There is no test suite currently. The `.env` file holds API keys (`POE_API_KEY`, `GEMINI_API_KEY`, `YOUTUBE_TRANSCRIPT_API_KEY`, `DISCORD_WEBHOOK_URL`).
+There is no test suite. Use `provider: "mock"` in a workflow step's config to invoke `MockLLMClient` (returns canned strings) without hitting any API. The `.env` file holds API keys (`POE_API_KEY`, `YOUTUBE_TRANSCRIPT_API_KEY`, `DISCORD_WEBHOOK_URL`).
 
 ## Architecture
 
@@ -39,7 +39,7 @@ There is no test suite currently. The `.env` file holds API keys (`POE_API_KEY`,
 
 1. `main.py` parses CLI args, creates a timestamped workspace under `outputs/YYYY-MM-DD_HHMMSS/`
 2. `WorkflowEngine` loads the YAML workflow and iterates over `steps`
-3. Each step's `type` maps to a registered task class
+3. Each step's `type` maps to a registered task class (imports happen in `engine.py`, not `__init__.py`)
 4. Tasks receive and mutate the shared `WorkflowContext` (a dict-like blackboard)
 5. `WorkflowContext` state is checkpointed to JSON so workflows can resume
 
@@ -47,13 +47,15 @@ There is no test suite currently. The `.env` file holds API keys (`POE_API_KEY`,
 
 | Component | Role |
 |---|---|
-| `PipelineTask` | Abstract base — all tasks implement `execute(context, config)` |
-| `WorkflowContext` | Shared state passed between every task (Blackboard Pattern) |
+| `PipelineTask` | Abstract base — all tasks implement `execute(context, config)`. Provides `get_workspace_path()` to resolve filenames relative to the run's workspace. |
+| `WorkflowContext` | Shared state. Use `context.require(key)` when a task strictly depends on a key (raises on missing); use `context.get(key, default)` otherwise. |
 | `WorkflowEngine` | Loads YAML, resolves tasks from registry, runs them sequentially |
 | `TaskRegistry` | `@register_task("name")` decorator maps YAML `type:` to Python class |
-| `ProductionLLMClient` | Multi-provider LLM client (Poe → Gemini → Ollama fallback chain) with output cleaning |
+| `ProductionLLMClient` | Multi-provider LLM client (Poe, Ollama) with retry logic and output cleaning |
 
 ### Workflow YAML Shape
+
+All file paths in workflow configs are relative to the **engine's working directory** (the repo root):
 
 ```yaml
 name: "Workflow Name"
@@ -61,16 +63,49 @@ steps:
   - id: step_id
     type: RegisteredTaskName   # must match @register_task("name")
     config:
-      key: value
+      input_key: "context_key"   # read from WorkflowContext
+      output_key: "result_key"   # written back to WorkflowContext
+      checkpoint_file: "run.json"
+      provider: "poe"            # poe | ollama | mock
+      model: "gemini-3-flash"
+      prompt_file: "path/to/prompt.txt"
 ```
+
+### Standardized Item Data Contract
+
+Tasks exchange lists of item dicts through the context. The canonical shape:
+
+```python
+{
+    "url": str,       # absolute URL or file path
+    "title": str,     # populated by TitleScrapingTask
+    "source": str,    # human-readable source name (falls back to url)
+    "content": str,   # populated by scraping/extraction tasks
+    "type": str,      # "datapoint" (automated) or "analysis" (HITL + deep LLM)
+    "format": str,    # "webpage" | "youtube" | "podcast" | "manual"
+    "tags": list,     # from sources CSV
+    "date": str,      # optional
+}
+```
+
+### Checkpoint Pattern
+
+Enrichment tasks use `CheckpointManager` for resumability. The pattern: load from the checkpoint JSON first, fall back to context, skip items that already have the output field populated, and save atomically after each item. This is what makes `--resume` work mid-pipeline.
+
+### LLM Provider Conventions
+
+| Provider + Model | Use case |
+|---|---|
+| `poe` + `gemini-3-flash` | Summarisation, synthesis (large context) |
+| `poe` + `gemini-3.1-flash-lite` | Fast/cheap datapoint trend extraction |
+| `ollama` + `qwen2.5:14b` | Local inference (e.g. region categorisation) |
+| `mock` | Local testing without API calls |
 
 ### Tasks (`src/tasks/`)
 
-25+ tasks registered with `@register_task`. Broad categories:
-
 - **Loaders**: `UrlListLoader`, `DirectoryLoader`, `SourceCSVLoader`
 - **Extractors**: `UniversalExtractorTask`, `ContentScrapingTask`, `TitleScrapingTask`, `SourceGatheringTask`, `ManualReviewTask`
-- **Transformers**: `LLMEnrichmentTask`, `BatchLLMTask`, `RegionCategorizationTask`, `SummarizationTask`
+- **Transformers**: `LLMTransformTask`, `BatchLLMTask`, `RegionCategorizationTask`, `SummarizationTask`
 - **Aggregators / Writers**: `TextAggregator`, `CitationCompilerTask`, `ReportWriterTask`, `ArtifactCheckpointTask`
 - **Delivery**: `CloudArchivalTask`, `GitPublisherTask`, `NotificationTask`
 - **Utilities**: `UserConfirmationTask`, `TextFileSplitterTask`, `BookDigestTask`, `ListMergerTask`, `StrategicSynthesisTask`, `ReportGenerationTask`
@@ -78,7 +113,7 @@ steps:
 ### Utilities (`src/utils/`)
 
 - `document.py` — `TextExtractor`, `PDFExtractor`, `EpubExtractor`
-- `io.py` — `CheckpointManager` (JSON persistence), `FileManager`
+- `io.py` — `CheckpointManager` (atomic JSON persistence), `FileManager`
 - `web.py`, `youtube.py`, `audio.py` — specialized content extractors
 - `formatting.py`, `notifications.py` — helpers
 
@@ -96,11 +131,10 @@ from src.core.registry import register_task
 @register_task("MyTaskName")
 class MyTask(PipelineTask):
     def execute(self, context: dict, config: dict) -> dict:
-        # read from context / config, write results back to context
         return context
 ```
 
-3. Import the module in `src/tasks/__init__.py` so the decorator fires on startup.
+3. Add the import to `src/core/engine.py` so the decorator fires at startup.
 
 ### Key Design Principles
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A declarative, configuration-driven cognitive automation platform — a workflow engine that uses LLMs to orchestrate data transformation, extraction, and synthesis pipelines. Workflows are defined in YAML; Python implements the individual tasks.
+
+## Commands
+
+```bash
+# Install dependencies
+poetry install --no-root
+
+# Run a workflow
+python main.py --workflow <path_to_workflow.yaml>
+
+# Resume a workflow from a checkpoint
+python main.py --workflow <path_to_workflow.yaml> --resume outputs/<workspace_dir>
+
+# Run with debug logging
+python main.py --workflow <path_to_workflow.yaml> --debug
+
+# Lint / format
+ruff check .
+ruff format .
+
+# Pre-commit (runs ruff, pyupgrade, file checks)
+pre-commit run --all-files
+```
+
+There is no test suite currently. The `.env` file holds API keys (`POE_API_KEY`, `GEMINI_API_KEY`, `YOUTUBE_TRANSCRIPT_API_KEY`, `DISCORD_WEBHOOK_URL`).
+
+## Architecture
+
+### Execution Flow
+
+`main.py` → `WorkflowEngine.run()` → sequential task execution via `TaskRegistry`
+
+1. `main.py` parses CLI args, creates a timestamped workspace under `outputs/YYYY-MM-DD_HHMMSS/`
+2. `WorkflowEngine` loads the YAML workflow and iterates over `steps`
+3. Each step's `type` maps to a registered task class
+4. Tasks receive and mutate the shared `WorkflowContext` (a dict-like blackboard)
+5. `WorkflowContext` state is checkpointed to JSON so workflows can resume
+
+### Core Abstractions (`src/core/`)
+
+| Component | Role |
+|---|---|
+| `PipelineTask` | Abstract base — all tasks implement `execute(context, config)` |
+| `WorkflowContext` | Shared state passed between every task (Blackboard Pattern) |
+| `WorkflowEngine` | Loads YAML, resolves tasks from registry, runs them sequentially |
+| `TaskRegistry` | `@register_task("name")` decorator maps YAML `type:` to Python class |
+| `ProductionLLMClient` | Multi-provider LLM client (Poe → Gemini → Ollama fallback chain) with output cleaning |
+
+### Workflow YAML Shape
+
+```yaml
+name: "Workflow Name"
+steps:
+  - id: step_id
+    type: RegisteredTaskName   # must match @register_task("name")
+    config:
+      key: value
+```
+
+### Tasks (`src/tasks/`)
+
+25+ tasks registered with `@register_task`. Broad categories:
+
+- **Loaders**: `UrlListLoader`, `DirectoryLoader`, `SourceCSVLoader`
+- **Extractors**: `UniversalExtractorTask`, `ContentScrapingTask`, `TitleScrapingTask`, `SourceGatheringTask`, `ManualReviewTask`
+- **Transformers**: `LLMEnrichmentTask`, `BatchLLMTask`, `RegionCategorizationTask`, `SummarizationTask`
+- **Aggregators / Writers**: `TextAggregator`, `CitationCompilerTask`, `ReportWriterTask`, `ArtifactCheckpointTask`
+- **Delivery**: `CloudArchivalTask`, `GitPublisherTask`, `NotificationTask`
+- **Utilities**: `UserConfirmationTask`, `TextFileSplitterTask`, `BookDigestTask`, `ListMergerTask`, `StrategicSynthesisTask`, `ReportGenerationTask`
+
+### Utilities (`src/utils/`)
+
+- `document.py` — `TextExtractor`, `PDFExtractor`, `EpubExtractor`
+- `io.py` — `CheckpointManager` (JSON persistence), `FileManager`
+- `web.py`, `youtube.py`, `audio.py` — specialized content extractors
+- `formatting.py`, `notifications.py` — helpers
+
+## Extending the System
+
+### Adding a New Task
+
+1. Create a file in `src/tasks/`
+2. Inherit from `PipelineTask` and decorate:
+
+```python
+from src.core.interfaces import PipelineTask
+from src.core.registry import register_task
+
+@register_task("MyTaskName")
+class MyTask(PipelineTask):
+    def execute(self, context: dict, config: dict) -> dict:
+        # read from context / config, write results back to context
+        return context
+```
+
+3. Import the module in `src/tasks/__init__.py` so the decorator fires on startup.
+
+### Key Design Principles
+
+- **"Logic Sandwich"**: Wrap probabilistic LLM calls between deterministic pre/post-processing steps.
+- **Declarative policy, imperative mechanism**: YAML controls flow and parameters; Python implements behaviour. Never hard-code workflow logic in task classes.
+- **Map-Reduce pattern**: `BatchLLMTask` processes list items individually; `TextAggregator` combines results.
+
+## Docs
+
+The `docs/` directory has detailed references:
+
+- `ARCHITECTURE.md` — core design rationale
+- `WORKFLOW_CONFIGURATION_GUIDE.md` — full task parameter reference
+- `DEVELOPMENT_GUIDE.md` — "Logic Sandwich" philosophy and inner/outer loop patterns
+- `SOURCES_CSV_GUIDE.md` — format for `SourceCSVLoader`
+- `FILE_NAMING_CONVENTION.md` — output file naming standards

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import os
 import datetime
 from dotenv import load_dotenv
 from src.core.engine import WorkflowEngine
+from src.utils.notifications import DiscordNotifier
 
 load_dotenv()
 
@@ -81,6 +82,10 @@ def main():
         engine.run()
     except Exception as e:
         logger.critical(f"Fatal error during execution: {e}", exc_info=True)
+        DiscordNotifier().send(
+            f"Workflow `{args.workflow}` failed: {e}",
+            level="error",
+        )
         sys.exit(1)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -948,27 +948,6 @@ test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_
 tqdm = ["tqdm"]
 
 [[package]]
-name = "google-ai-generativelanguage"
-version = "0.6.15"
-description = "Google Ai Generativelanguage API client library"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "google_ai_generativelanguage-0.6.15-py3-none-any.whl", hash = "sha256:5a03ef86377aa184ffef3662ca28f19eeee158733e45d7947982eb953c6ebb6c"},
-    {file = "google_ai_generativelanguage-0.6.15.tar.gz", hash = "sha256:8f6d9dc4c12b065fe2d0289026171acea5183ebf2d0b11cefe12f3821e159ec3"},
-]
-
-[package.dependencies]
-google-api-core = {version = ">=1.34.1,<2.0.dev0 || >=2.11.dev0,<3.0.0.dev0", extras = ["grpc"]}
-google-auth = ">=2.14.1,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0.dev0"
-proto-plus = [
-    {version = ">=1.22.3,<2.0.0.dev0"},
-    {version = ">=1.25.0,<2.0.0.dev0", markers = "python_version >= \"3.13\""},
-]
-protobuf = ">=3.20.2,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<6.0.0.dev0"
-
-[[package]]
 name = "google-api-core"
 version = "2.29.0"
 description = "Google API client core library"
@@ -983,14 +962,6 @@ files = [
 [package.dependencies]
 google-auth = ">=2.14.1,<3.0.0"
 googleapis-common-protos = ">=1.56.2,<2.0.0"
-grpcio = [
-    {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
-    {version = ">=1.33.2,<2.0.0", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
-]
-grpcio-status = [
-    {version = ">=1.49.1,<2.0.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
-    {version = ">=1.33.2,<2.0.0", optional = true, markers = "extra == \"grpc\""},
-]
 proto-plus = [
     {version = ">=1.22.3,<2.0.0"},
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
@@ -1066,30 +1037,6 @@ files = [
 [package.dependencies]
 google-auth = ">=1.32.0,<3.0.0"
 httplib2 = ">=0.19.0,<1.0.0"
-
-[[package]]
-name = "google-generativeai"
-version = "0.8.6"
-description = "Google Generative AI High level API client library and tools."
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "google_generativeai-0.8.6-py3-none-any.whl", hash = "sha256:37a0eaaa95e5bbf888828e20a4a1b2c196cc9527d194706e58a68ff388aeb0fa"},
-]
-
-[package.dependencies]
-google-ai-generativelanguage = "0.6.15"
-google-api-core = "*"
-google-api-python-client = "*"
-google-auth = ">=2.15.0"
-protobuf = "*"
-pydantic = "*"
-tqdm = "*"
-typing-extensions = "*"
-
-[package.extras]
-dev = ["Pillow", "absl-py", "black", "ipython", "nose2", "pandas", "pytype", "pyyaml"]
 
 [[package]]
 name = "googleapis-common-protos"
@@ -1176,100 +1123,6 @@ files = [
 [package.extras]
 docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil", "setuptools"]
-
-[[package]]
-name = "grpcio"
-version = "1.76.0"
-description = "HTTP/2-based RPC framework"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "grpcio-1.76.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:65a20de41e85648e00305c1bb09a3598f840422e522277641145a32d42dcefcc"},
-    {file = "grpcio-1.76.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:40ad3afe81676fd9ec6d9d406eda00933f218038433980aa19d401490e46ecde"},
-    {file = "grpcio-1.76.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:035d90bc79eaa4bed83f524331d55e35820725c9fbb00ffa1904d5550ed7ede3"},
-    {file = "grpcio-1.76.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4215d3a102bd95e2e11b5395c78562967959824156af11fa93d18fdd18050990"},
-    {file = "grpcio-1.76.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:49ce47231818806067aea3324d4bf13825b658ad662d3b25fada0bdad9b8a6af"},
-    {file = "grpcio-1.76.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8cc3309d8e08fd79089e13ed4819d0af72aa935dd8f435a195fd152796752ff2"},
-    {file = "grpcio-1.76.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:971fd5a1d6e62e00d945423a567e42eb1fa678ba89072832185ca836a94daaa6"},
-    {file = "grpcio-1.76.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d9adda641db7207e800a7f089068f6f645959f2df27e870ee81d44701dd9db3"},
-    {file = "grpcio-1.76.0-cp310-cp310-win32.whl", hash = "sha256:063065249d9e7e0782d03d2bca50787f53bd0fb89a67de9a7b521c4a01f1989b"},
-    {file = "grpcio-1.76.0-cp310-cp310-win_amd64.whl", hash = "sha256:a6ae758eb08088d36812dd5d9af7a9859c05b1e0f714470ea243694b49278e7b"},
-    {file = "grpcio-1.76.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2e1743fbd7f5fa713a1b0a8ac8ebabf0ec980b5d8809ec358d488e273b9cf02a"},
-    {file = "grpcio-1.76.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a8c2cf1209497cf659a667d7dea88985e834c24b7c3b605e6254cbb5076d985c"},
-    {file = "grpcio-1.76.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08caea849a9d3c71a542827d6df9d5a69067b0a1efbea8a855633ff5d9571465"},
-    {file = "grpcio-1.76.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f0e34c2079d47ae9f6188211db9e777c619a21d4faba6977774e8fa43b085e48"},
-    {file = "grpcio-1.76.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8843114c0cfce61b40ad48df65abcfc00d4dba82eae8718fab5352390848c5da"},
-    {file = "grpcio-1.76.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8eddfb4d203a237da6f3cc8a540dad0517d274b5a1e9e636fd8d2c79b5c1d397"},
-    {file = "grpcio-1.76.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:32483fe2aab2c3794101c2a159070584e5db11d0aa091b2c0ea9c4fc43d0d749"},
-    {file = "grpcio-1.76.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dcfe41187da8992c5f40aa8c5ec086fa3672834d2be57a32384c08d5a05b4c00"},
-    {file = "grpcio-1.76.0-cp311-cp311-win32.whl", hash = "sha256:2107b0c024d1b35f4083f11245c0e23846ae64d02f40b2b226684840260ed054"},
-    {file = "grpcio-1.76.0-cp311-cp311-win_amd64.whl", hash = "sha256:522175aba7af9113c48ec10cc471b9b9bd4f6ceb36aeb4544a8e2c80ed9d252d"},
-    {file = "grpcio-1.76.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:81fd9652b37b36f16138611c7e884eb82e0cec137c40d3ef7c3f9b3ed00f6ed8"},
-    {file = "grpcio-1.76.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:04bbe1bfe3a68bbfd4e52402ab7d4eb59d72d02647ae2042204326cf4bbad280"},
-    {file = "grpcio-1.76.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d388087771c837cdb6515539f43b9d4bf0b0f23593a24054ac16f7a960be16f4"},
-    {file = "grpcio-1.76.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:9f8f757bebaaea112c00dba718fc0d3260052ce714e25804a03f93f5d1c6cc11"},
-    {file = "grpcio-1.76.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:980a846182ce88c4f2f7e2c22c56aefd515daeb36149d1c897f83cf57999e0b6"},
-    {file = "grpcio-1.76.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f92f88e6c033db65a5ae3d97905c8fea9c725b63e28d5a75cb73b49bda5024d8"},
-    {file = "grpcio-1.76.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4baf3cbe2f0be3289eb68ac8ae771156971848bb8aaff60bad42005539431980"},
-    {file = "grpcio-1.76.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:615ba64c208aaceb5ec83bfdce7728b80bfeb8be97562944836a7a0a9647d882"},
-    {file = "grpcio-1.76.0-cp312-cp312-win32.whl", hash = "sha256:45d59a649a82df5718fd9527ce775fd66d1af35e6d31abdcdc906a49c6822958"},
-    {file = "grpcio-1.76.0-cp312-cp312-win_amd64.whl", hash = "sha256:c088e7a90b6017307f423efbb9d1ba97a22aa2170876223f9709e9d1de0b5347"},
-    {file = "grpcio-1.76.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:26ef06c73eb53267c2b319f43e6634c7556ea37672029241a056629af27c10e2"},
-    {file = "grpcio-1.76.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:45e0111e73f43f735d70786557dc38141185072d7ff8dc1829d6a77ac1471468"},
-    {file = "grpcio-1.76.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83d57312a58dcfe2a3a0f9d1389b299438909a02db60e2f2ea2ae2d8034909d3"},
-    {file = "grpcio-1.76.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:3e2a27c89eb9ac3d81ec8835e12414d73536c6e620355d65102503064a4ed6eb"},
-    {file = "grpcio-1.76.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61f69297cba3950a524f61c7c8ee12e55c486cb5f7db47ff9dcee33da6f0d3ae"},
-    {file = "grpcio-1.76.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a15c17af8839b6801d554263c546c69c4d7718ad4321e3166175b37eaacca77"},
-    {file = "grpcio-1.76.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:25a18e9810fbc7e7f03ec2516addc116a957f8cbb8cbc95ccc80faa072743d03"},
-    {file = "grpcio-1.76.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:931091142fd8cc14edccc0845a79248bc155425eee9a98b2db2ea4f00a235a42"},
-    {file = "grpcio-1.76.0-cp313-cp313-win32.whl", hash = "sha256:5e8571632780e08526f118f74170ad8d50fb0a48c23a746bef2a6ebade3abd6f"},
-    {file = "grpcio-1.76.0-cp313-cp313-win_amd64.whl", hash = "sha256:f9f7bd5faab55f47231ad8dba7787866b69f5e93bc306e3915606779bbfb4ba8"},
-    {file = "grpcio-1.76.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:ff8a59ea85a1f2191a0ffcc61298c571bc566332f82e5f5be1b83c9d8e668a62"},
-    {file = "grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:06c3d6b076e7b593905d04fdba6a0525711b3466f43b3400266f04ff735de0cd"},
-    {file = "grpcio-1.76.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd5ef5932f6475c436c4a55e4336ebbe47bd3272be04964a03d316bbf4afbcbc"},
-    {file = "grpcio-1.76.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b331680e46239e090f5b3cead313cc772f6caa7d0fc8de349337563125361a4a"},
-    {file = "grpcio-1.76.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2229ae655ec4e8999599469559e97630185fdd53ae1e8997d147b7c9b2b72cba"},
-    {file = "grpcio-1.76.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:490fa6d203992c47c7b9e4a9d39003a0c2bcc1c9aa3c058730884bbbb0ee9f09"},
-    {file = "grpcio-1.76.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:479496325ce554792dba6548fae3df31a72cef7bad71ca2e12b0e58f9b336bfc"},
-    {file = "grpcio-1.76.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1c9b93f79f48b03ada57ea24725d83a30284a012ec27eab2cf7e50a550cbbbcc"},
-    {file = "grpcio-1.76.0-cp314-cp314-win32.whl", hash = "sha256:747fa73efa9b8b1488a95d0ba1039c8e2dca0f741612d80415b1e1c560febf4e"},
-    {file = "grpcio-1.76.0-cp314-cp314-win_amd64.whl", hash = "sha256:922fa70ba549fce362d2e2871ab542082d66e2aaf0c19480ea453905b01f384e"},
-    {file = "grpcio-1.76.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:8ebe63ee5f8fa4296b1b8cfc743f870d10e902ca18afc65c68cf46fd39bb0783"},
-    {file = "grpcio-1.76.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:3bf0f392c0b806905ed174dcd8bdd5e418a40d5567a05615a030a5aeddea692d"},
-    {file = "grpcio-1.76.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b7604868b38c1bfd5cf72d768aedd7db41d78cb6a4a18585e33fb0f9f2363fd"},
-    {file = "grpcio-1.76.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:e6d1db20594d9daba22f90da738b1a0441a7427552cc6e2e3d1297aeddc00378"},
-    {file = "grpcio-1.76.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d099566accf23d21037f18a2a63d323075bebace807742e4b0ac210971d4dd70"},
-    {file = "grpcio-1.76.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ebea5cc3aa8ea72e04df9913492f9a96d9348db876f9dda3ad729cfedf7ac416"},
-    {file = "grpcio-1.76.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:0c37db8606c258e2ee0c56b78c62fc9dee0e901b5dbdcf816c2dd4ad652b8b0c"},
-    {file = "grpcio-1.76.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ebebf83299b0cb1721a8859ea98f3a77811e35dce7609c5c963b9ad90728f886"},
-    {file = "grpcio-1.76.0-cp39-cp39-win32.whl", hash = "sha256:0aaa82d0813fd4c8e589fac9b65d7dd88702555f702fb10417f96e2a2a6d4c0f"},
-    {file = "grpcio-1.76.0-cp39-cp39-win_amd64.whl", hash = "sha256:acab0277c40eff7143c2323190ea57b9ee5fd353d8190ee9652369fae735668a"},
-    {file = "grpcio-1.76.0.tar.gz", hash = "sha256:7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73"},
-]
-
-[package.dependencies]
-typing-extensions = ">=4.12,<5.0"
-
-[package.extras]
-protobuf = ["grpcio-tools (>=1.76.0)"]
-
-[[package]]
-name = "grpcio-status"
-version = "1.71.2"
-description = "Status proto mapping for gRPC"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "grpcio_status-1.71.2-py3-none-any.whl", hash = "sha256:803c98cb6a8b7dc6dbb785b1111aed739f241ab5e9da0bba96888aa74704cfd3"},
-    {file = "grpcio_status-1.71.2.tar.gz", hash = "sha256:c7a97e176df71cdc2c179cd1847d7fc86cca5832ad12e9798d7fed6b7a1aab50"},
-]
-
-[package.dependencies]
-googleapis-common-protos = ">=1.5.5"
-grpcio = ">=1.71.2"
-protobuf = ">=5.26.1,<6.0.dev0"
 
 [[package]]
 name = "h11"
@@ -2988,9 +2841,9 @@ files = [
 
 [package.dependencies]
 numpy = [
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -3278,7 +3131,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "(os_name == \"nt\" or platform_python_implementation != \"PyPy\") and (implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\") and implementation_name != \"PyPy\""
+markers = "(os_name == \"nt\" or platform_python_implementation != \"PyPy\") and (platform_python_implementation != \"PyPy\" or implementation_name != \"pypy\" and implementation_name != \"PyPy\") and implementation_name != \"PyPy\""
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
@@ -3971,7 +3824,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version < \"3.13\" and (python_version == \"3.12\" or platform_system == \"Linux\" or platform_machine == \"x86_64\" or sys_platform == \"linux2\") and (python_version == \"3.12\" or platform_system == \"Linux\" or sys_platform == \"linux\" or sys_platform == \"linux2\") or python_version == \"3.13\""
+markers = "(platform_machine == \"x86_64\" or platform_system == \"Linux\" or sys_platform == \"linux2\" or python_version == \"3.12\") and python_version <= \"3.12\" and (sys_platform == \"linux\" or sys_platform == \"linux2\" or platform_system == \"Linux\" or python_version == \"3.12\") or python_version == \"3.13\""
 files = [
     {file = "setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173"},
     {file = "setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70"},
@@ -5007,4 +4860,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "c82a0c86e1f3538fd83dc1461e612c054242ac673d8e8646784a7c385895fd46"
+content-hash = "65b152ece93b409c0bccaa9ea40224d1d0702269519e1aa088704949c6a14d2a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ requests = "^2.32.5"
 pymupdf4llm = "^0.2.9"
 ebooklib = "^0.20"
 pymupdf-layout = "^1.26.6"
-google-generativeai = "^0.8.6"
 jinja2 = "^3.1.6"
 boto3 = "^1.42.53"
 

--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -7,7 +7,6 @@ from typing import Dict, Any
 
 import openai
 from langchain_community.llms import Ollama
-import google.generativeai as genai
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +29,6 @@ class MockLLMClient(BaseLLMClient):
 
 class ProductionLLMClient(BaseLLMClient):
     DEFAULT_POE_MODEL = "gemini-3-flash"
-    DEFAULT_GEMINI_MODEL = "gemini-3-flash"
     DEFAULT_OLLAMA_MODEL = "qwen2.5:14b"
     DEFAULT_FALLBACK_MODEL = "deepseek-r1:8b"
 
@@ -68,13 +66,6 @@ class ProductionLLMClient(BaseLLMClient):
             self.client = openai.OpenAI(
                 api_key=api_key, base_url="https://api.poe.com/v1"
             )
-
-        elif self.provider == "gemini":
-            api_key = os.getenv("GEMINI_API_KEY")
-            if not api_key:
-                logger.error("GEMINI_API_KEY not found in environment variables.")
-                raise ValueError("Missing GEMINI_API_KEY")
-            genai.configure(api_key=api_key)
 
         elif self.provider == "ollama":
             pass
@@ -139,8 +130,6 @@ class ProductionLLMClient(BaseLLMClient):
     def _query_primary_provider(self, prompt: str, model: str) -> str:
         if self.provider == "poe":
             return self._query_poe(prompt, model)
-        elif self.provider == "gemini":
-            return self._query_gemini(prompt, model)
         elif self.provider == "ollama":
             return self._query_ollama(prompt, model)
         else:
@@ -155,13 +144,6 @@ class ProductionLLMClient(BaseLLMClient):
             temperature=0.0,
         )
         return self._clean_llm_output(response.choices[0].message.content)
-
-    def _query_gemini(self, prompt: str, model: str) -> str:
-        target_model = model if model != "default" else self.DEFAULT_GEMINI_MODEL
-        logger.info(f"Querying Google Gemini with model: {target_model}")
-        model_instance = genai.GenerativeModel(target_model)
-        response = model_instance.generate_content(prompt)
-        return self._clean_llm_output(response.text)
 
     def _query_ollama(self, prompt: str, model: str) -> str:
         target_model = model if model != "default" else self.DEFAULT_OLLAMA_MODEL

--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import time
+import re
 from abc import ABC, abstractmethod
 from typing import Dict, Any
 
@@ -27,9 +29,36 @@ class MockLLMClient(BaseLLMClient):
 
 
 class ProductionLLMClient(BaseLLMClient):
+    DEFAULT_POE_MODEL = "gemini-3-flash"
+    DEFAULT_GEMINI_MODEL = "gemini-3-flash"
+    DEFAULT_OLLAMA_MODEL = "qwen2.5:14b"
+    DEFAULT_FALLBACK_MODEL = "deepseek-r1:8b"
+
     def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.provider = config.get("provider", "poe").lower()
+
+        self.max_retries = config.get("max_retries", 2)
+        self.base_delay = config.get("retry_delay", 2)
+        self.fallback_enabled = config.get("fallback_enabled", True)
+
+        # Use class constant for fallback default
+        self.fallback_model = config.get("fallback_model", self.DEFAULT_FALLBACK_MODEL)
+
+        # Block Patterns: Regexes to remove entire chunks (multiline)
+        self.cleaning_block_patterns = [
+            r"<think>.*?</think>",
+            r"<thought>.*?</thought>",
+            r"\[Thinking:.*?\]",
+            r"Thinking.*?...done thinking.",
+        ]
+
+        # Line Prefixes: Remove lines starting with these (case-insensitive)
+        self.cleaning_line_prefixes = [
+            ">",
+            "*thinking",
+            "thinking:",
+        ]
 
         if self.provider == "poe":
             api_key = os.getenv("POE_API_KEY")
@@ -47,75 +76,124 @@ class ProductionLLMClient(BaseLLMClient):
                 raise ValueError("Missing GEMINI_API_KEY")
             genai.configure(api_key=api_key)
 
-        # Setup Ollama (No Auth needed for local)
         elif self.provider == "ollama":
-            # We don't need persistent client for LangChain Ollama, we instantiate per call
             pass
 
     def query(self, prompt: str, model: str = "default") -> str:
+        """
+        Orchestrates the query with:
+        1. Mandatory cooldown (Rate Limit protection).
+        2. Primary Provider attempt with Exponential Backoff.
+        3. Hot Fallback to Local LLM if Primary fails.
+        """
+
+        time.sleep(1.0)  # Mandatory Cooldown
+
         try:
-            if self.provider == "poe":
-                return self._query_poe(prompt, model)
-            elif self.provider == "gemini":
-                return self._query_gemini(prompt, model)
-            elif self.provider == "ollama":
-                return self._query_ollama(prompt, model)
-            else:
-                raise ValueError(f"Unknown provider: {self.provider}")
+            return self._execute_with_retry(
+                provider_func=self._query_primary_provider,
+                prompt=prompt,
+                model=model,
+                retries=self.max_retries,
+                provider_name=self.provider,
+            )
         except Exception as e:
-            logger.error(f"LLM Query Failed ({self.provider}/{model}): {e}")
-            return f"[Error: {e}]"
+            logger.error(
+                f"Primary Provider ({self.provider}) failed after retries: {e}"
+            )
+
+            if self.fallback_enabled and self.provider != "ollama":
+                logger.warning(
+                    f"⚠️ Initiating Hot Fallback to Local Ollama ({self.fallback_model})..."
+                )
+                try:
+                    return self._execute_with_retry(
+                        provider_func=self._query_ollama,
+                        prompt=prompt,
+                        model=self.fallback_model,
+                        retries=2,
+                        provider_name="ollama-fallback",
+                    )
+                except Exception as fallback_error:
+                    logger.critical(f"Fallback failed: {fallback_error}")
+
+            return f"[Error: All LLM providers failed. Primary: {e}]"
+
+    def _execute_with_retry(self, provider_func, prompt, model, retries, provider_name):
+        last_exception = None
+        for attempt in range(1, retries + 1):
+            try:
+                if attempt > 1:
+                    logger.info(
+                        f"Retry attempt {attempt}/{retries} for {provider_name}..."
+                    )
+                return provider_func(prompt, model)
+            except Exception as e:
+                last_exception = e
+                logger.warning(f"Attempt {attempt} failed for {provider_name}: {e}")
+                if attempt < retries:
+                    sleep_time = self.base_delay * (2 ** (attempt - 1))
+                    time.sleep(sleep_time)
+        raise last_exception
+
+    def _query_primary_provider(self, prompt: str, model: str) -> str:
+        if self.provider == "poe":
+            return self._query_poe(prompt, model)
+        elif self.provider == "gemini":
+            return self._query_gemini(prompt, model)
+        elif self.provider == "ollama":
+            return self._query_ollama(prompt, model)
+        else:
+            raise ValueError(f"Unknown provider: {self.provider}")
 
     def _query_poe(self, prompt: str, model: str) -> str:
-        # Default to a safe model if 'default' is passed
-        target_model = model if model != "default" else "Gemini-2.5-Flash"
-
+        target_model = model if model != "default" else self.DEFAULT_POE_MODEL
         logger.info(f"Querying Poe API with model: {target_model}")
         response = self.client.chat.completions.create(
             model=target_model,
             messages=[{"role": "user", "content": prompt}],
-            temperature=0.0,  # Deterministic
+            temperature=0.0,
         )
         return self._clean_llm_output(response.choices[0].message.content)
 
     def _query_gemini(self, prompt: str, model: str) -> str:
-        # Default to Flash if not specified
-        target_model = model if model != "default" else "gemini-2.5-flash"
-
+        target_model = model if model != "default" else self.DEFAULT_GEMINI_MODEL
         logger.info(f"Querying Google Gemini with model: {target_model}")
         model_instance = genai.GenerativeModel(target_model)
         response = model_instance.generate_content(prompt)
         return self._clean_llm_output(response.text)
 
     def _query_ollama(self, prompt: str, model: str) -> str:
-        target_model = model if model != "default" else "qwen2.5:14b"
-
+        target_model = model if model != "default" else self.DEFAULT_OLLAMA_MODEL
         logger.info(f"Querying Local Ollama with model: {target_model}")
         llm = Ollama(model=target_model, temperature=0.0)
-        return llm.invoke(prompt)
+        return self._clean_llm_output(llm.invoke(prompt))
 
     def _clean_llm_output(self, text: str) -> str:
         """
-        Removes meta-commentary, 'thinking' lines, and blockquotes from the LLM output.
-        Target patterns:
-        - "*Thinking...*"
-        - "> Blockquoted thought process"
+        Modular cleaning of LLM output based on configured patterns.
+        1. Removes multi-line blocks (regex).
+        2. Filters out specific lines (prefixes).
         """
         if not text:
             return ""
 
+        # 1. Block Removal
+        # Uses DOTALL so . matches newlines, IGNORECASE for <Think> vs <think>
+        for pattern in self.cleaning_block_patterns:
+            text = re.sub(pattern, "", text, flags=re.DOTALL | re.IGNORECASE)
+
+        # 2. Line Filtering
         lines = text.splitlines()
         cleaned_lines = []
 
         for line in lines:
-            stripped = line.strip()
+            stripped = line.strip().lower()
 
-            # Filter out blockquotes (standard CoT format for some models)
-            if stripped.startswith(">"):
-                continue
-
-            # Filter out italicized thinking markers (e.g. *Thinking...*)
-            if stripped.lower().startswith("*thinking"):
+            # Check if line starts with any forbidden prefix
+            if any(
+                stripped.startswith(prefix) for prefix in self.cleaning_line_prefixes
+            ):
                 continue
 
             cleaned_lines.append(line)
@@ -124,9 +202,6 @@ class ProductionLLMClient(BaseLLMClient):
 
 
 def get_llm_client(config: Dict[str, Any]) -> BaseLLMClient:
-    # Check if 'mock' is explicitly requested in the step config
     if config.get("provider") == "mock":
         return MockLLMClient()
-
-    # Otherwise, check environment mode or default to Production
     return ProductionLLMClient(config)

--- a/src/core/llm.py
+++ b/src/core/llm.py
@@ -30,7 +30,6 @@ class MockLLMClient(BaseLLMClient):
 class ProductionLLMClient(BaseLLMClient):
     DEFAULT_POE_MODEL = "gemini-3-flash"
     DEFAULT_OLLAMA_MODEL = "qwen2.5:14b"
-    DEFAULT_FALLBACK_MODEL = "deepseek-r1:8b"
 
     def __init__(self, config: Dict[str, Any]):
         self.config = config
@@ -38,10 +37,6 @@ class ProductionLLMClient(BaseLLMClient):
 
         self.max_retries = config.get("max_retries", 2)
         self.base_delay = config.get("retry_delay", 2)
-        self.fallback_enabled = config.get("fallback_enabled", True)
-
-        # Use class constant for fallback default
-        self.fallback_model = config.get("fallback_model", self.DEFAULT_FALLBACK_MODEL)
 
         # Block Patterns: Regexes to remove entire chunks (multiline)
         self.cleaning_block_patterns = [
@@ -71,44 +66,14 @@ class ProductionLLMClient(BaseLLMClient):
             pass
 
     def query(self, prompt: str, model: str = "default") -> str:
-        """
-        Orchestrates the query with:
-        1. Mandatory cooldown (Rate Limit protection).
-        2. Primary Provider attempt with Exponential Backoff.
-        3. Hot Fallback to Local LLM if Primary fails.
-        """
-
         time.sleep(1.0)  # Mandatory Cooldown
-
-        try:
-            return self._execute_with_retry(
-                provider_func=self._query_primary_provider,
-                prompt=prompt,
-                model=model,
-                retries=self.max_retries,
-                provider_name=self.provider,
-            )
-        except Exception as e:
-            logger.error(
-                f"Primary Provider ({self.provider}) failed after retries: {e}"
-            )
-
-            if self.fallback_enabled and self.provider != "ollama":
-                logger.warning(
-                    f"⚠️ Initiating Hot Fallback to Local Ollama ({self.fallback_model})..."
-                )
-                try:
-                    return self._execute_with_retry(
-                        provider_func=self._query_ollama,
-                        prompt=prompt,
-                        model=self.fallback_model,
-                        retries=2,
-                        provider_name="ollama-fallback",
-                    )
-                except Exception as fallback_error:
-                    logger.critical(f"Fallback failed: {fallback_error}")
-
-            return f"[Error: All LLM providers failed. Primary: {e}]"
+        return self._execute_with_retry(
+            provider_func=self._query_primary_provider,
+            prompt=prompt,
+            model=model,
+            retries=self.max_retries,
+            provider_name=self.provider,
+        )
 
     def _execute_with_retry(self, provider_func, prompt, model, retries, provider_name):
         last_exception = None

--- a/src/tasks/extractors.py
+++ b/src/tasks/extractors.py
@@ -420,7 +420,14 @@ class ContentScrapingTask(PipelineTask):
                 try:
                     content_result = ""
 
-                    if fmt == "youtube":
+                    if fmt == "manual":
+                        logger.info(
+                            f"Skipping automated scrape for manual item: {item.get('url')}"
+                        )
+                        # Initialize the key so HITL catches it as empty
+                        item.setdefault("content", "")
+                        continue
+                    elif fmt == "youtube":
                         if typ == "datapoint":
                             content_result = self._scrape_youtube_headlines(url)
                         else:
@@ -568,7 +575,14 @@ class TitleScrapingTask(PipelineTask):
 
                 try:
                     # 3. Routing
-                    if fmt == "youtube":
+                    if fmt == "manual":
+                        logger.info(
+                            f"Skipping automated scrape for manual item: {item.get('url')}"
+                        )
+                        # Ensure the keys exist so HITL doesn't throw a KeyError later
+                        item.setdefault("title", "")
+                        continue
+                    elif fmt == "youtube":
                         fetched_title = yt_extractor.get_video_title(url)
                     elif fmt == "podcast":
                         fetched_title = self._format_filename_to_title(url)

--- a/src/tasks/synthesis.py
+++ b/src/tasks/synthesis.py
@@ -93,16 +93,12 @@ class StrategicSynthesisTask(PipelineTask):
             logger.info(
                 "StrategicSynthesisTask: Generating Global Executive Summary..."
             )
-            try:
-                prompt = global_template.format(
-                    global_trends=global_trends_text,
-                    all_analysis_briefs=all_analysis_text,
-                )
-                global_summary = llm_client.query(prompt, model=config.get("model"))
-                intelligence["Global_Executive_Summary"] = global_summary
-            except Exception as e:
-                logger.error(f"Global Summary Failed: {e}")
-                intelligence["Global_Executive_Summary"] = "Generation Failed."
+            prompt = global_template.format(
+                global_trends=global_trends_text,
+                all_analysis_briefs=all_analysis_text,
+            )
+            global_summary = llm_client.query(prompt, model=config.get("model"))
+            intelligence["Global_Executive_Summary"] = global_summary
 
         # --- 5. Category Assessments ---
         for category_name, category_items in grouped_items.items():
@@ -134,19 +130,15 @@ class StrategicSynthesisTask(PipelineTask):
                 cat_text_list.append(txt)
             category_intel_text = "\n\n---\n\n".join(cat_text_list)
 
-            try:
-                prompt = category_template.format(
-                    category_name=category_name,
-                    global_summary=intelligence.get("Global_Executive_Summary", ""),
-                    category_intel=category_intel_text,
-                )
-                assessment = llm_client.query(prompt, model=config.get("model"))
+            prompt = category_template.format(
+                category_name=category_name,
+                global_summary=intelligence.get("Global_Executive_Summary", ""),
+                category_intel=category_intel_text,
+            )
+            assessment = llm_client.query(prompt, model=config.get("model"))
 
-                intelligence[category_name]["assessment"] = assessment
-                intelligence[category_name]["articles"] = category_items
-
-            except Exception as e:
-                logger.error(f"Assessment failed for {category_name}: {e}")
+            intelligence[category_name]["assessment"] = assessment
+            intelligence[category_name]["articles"] = category_items
 
         artifact["intelligence"] = intelligence
         CheckpointManager.save(checkpoint_file, artifact)

--- a/src/tasks/transformers.py
+++ b/src/tasks/transformers.py
@@ -154,6 +154,7 @@ class LLMEnrichmentTask(PipelineTask):
 
         target_types = config.get("target_types", [])
         input_fields = config.get("input_fields", ["title", "content"])
+        force_refresh = config.get("force_refresh", False)
 
         max_chars = config.get("max_chars", 3000)
 
@@ -196,7 +197,7 @@ class LLMEnrichmentTask(PipelineTask):
             if target_types and item.get("type") not in target_types:
                 continue
 
-            if item.get(output_key):
+            if not force_refresh and item.get(output_key):
                 continue
 
             # Build Context

--- a/src/tasks/transformers.py
+++ b/src/tasks/transformers.py
@@ -300,6 +300,7 @@ class RegionCategorizationTask(LLMEnrichmentTask):
         "asia": "East Asia",
         "unknown": "Global",
         "global": "Global",
+        "russia & former soviet union": "Russia",
     }
 
     def _post_process_response(self, text: str) -> str:

--- a/src/tasks/transformers.py
+++ b/src/tasks/transformers.py
@@ -109,11 +109,7 @@ class BatchLLMTask(PipelineTask):
 
             final_prompt = prompt_template.format(content=content)
 
-            try:
-                llm_output = llm_client.query(final_prompt, model=model_name)
-            except Exception as e:
-                logger.error(f"LLM failure for {original_source}: {e}")
-                llm_output = f"[Error processing {original_source}]"
+            llm_output = llm_client.query(final_prompt, model=model_name)
 
             metadata_section = (
                 f"## Metadata\n"
@@ -222,21 +218,17 @@ class LLMEnrichmentTask(PipelineTask):
 
             merged_context = "\n\n".join(combined_parts)
 
-            try:
-                final_prompt = prompt_template.format(content=merged_context)
+            final_prompt = prompt_template.format(content=merged_context)
 
-                response = llm_client.query(final_prompt, model=model_name)
+            response = llm_client.query(final_prompt, model=model_name)
 
-                cleaned_response = self._post_process_response(response)
+            cleaned_response = self._post_process_response(response)
 
-                item[output_key] = cleaned_response
-                updated = True
+            item[output_key] = cleaned_response
+            updated = True
 
-                artifact[target_key] = items
-                CheckpointManager.save(checkpoint_file, artifact)
-
-            except Exception as e:
-                logger.error(f"LLM Enrichment failed for {item.get('url')}: {e}")
+            artifact[target_key] = items
+            CheckpointManager.save(checkpoint_file, artifact)
 
         if updated:
             context.set(target_key, items)

--- a/src/tasks/transformers.py
+++ b/src/tasks/transformers.py
@@ -197,14 +197,6 @@ class LLMEnrichmentTask(PipelineTask):
             limit_per_field = int(max_chars / len(input_fields))
 
         for item in items:
-            if item.get("format", "").lower() == "manual":
-                logger.info(
-                    f"Skipping LLM enrichment ({output_key}) for manual item: {item.get('url')}"
-                )
-                # Initialize the key so HITL catches it as empty
-                item.setdefault(output_key, "")
-                continue
-
             if target_types and item.get("type") not in target_types:
                 continue
 
@@ -321,11 +313,11 @@ class RegionCategorizationTask(LLMEnrichmentTask):
             if cat.lower() == cleaned_lower:
                 return cat
 
-        # Fallback: Return empty string so ManualReviewTask catches it
         logger.warning(
-            f"RegionCategorizationTask: Invalid category '{cleaned}'. Returning empty for manual fix."
+            f"RegionCategorizationTask: Invalid category '{cleaned}' returned."
         )
-        return ""
+        # Default to 'Global' if unrecognized, as it's the most inclusive category
+        return "Global"
 
 
 @register_task("SummarizationTask")

--- a/src/tasks/transformers.py
+++ b/src/tasks/transformers.py
@@ -197,6 +197,14 @@ class LLMEnrichmentTask(PipelineTask):
             limit_per_field = int(max_chars / len(input_fields))
 
         for item in items:
+            if item.get("format", "").lower() == "manual":
+                logger.info(
+                    f"Skipping LLM enrichment ({output_key}) for manual item: {item.get('url')}"
+                )
+                # Initialize the key so HITL catches it as empty
+                item.setdefault(output_key, "")
+                continue
+
             if target_types and item.get("type") not in target_types:
                 continue
 

--- a/src/tasks/transformers.py
+++ b/src/tasks/transformers.py
@@ -295,6 +295,11 @@ class RegionCategorizationTask(LLMEnrichmentTask):
         "australia": "Oceania",
         "latin america": "Latin America & Caribbean",
         "caribbean": "Latin America & Caribbean",
+        "south america": "Latin America & Caribbean",
+        "the americas": "North America",
+        "asia": "East Asia",
+        "unknown": "Global",
+        "global": "Global",
     }
 
     def _post_process_response(self, text: str) -> str:


### PR DESCRIPTION
Pipeline Reliability & Resilience Upgrades

## Summary

Hardens the pipeline for high-volume automated runs by addressing API fragility, LLM hallucinations in region categorisation, and missing cache override controls.

## Changes

### LLM Retry Logic (`src/core/llm.py`)
- Added `_execute_with_retry()` with exponential backoff (configurable `max_retries` and `base_delay`) — handles transient HTTP 429s and timeouts without cascading failures.
- Hot fallback to Ollama was evaluated and dropped; output was unpredictable. Fail-fast behaviour is preserved after retries are exhausted.
- Removed `google-generativeai` SDK and `_query_gemini()` — Gemini is now accessed via Poe only.
- Enhanced `_clean_llm_output()` with configurable regex patterns to strip thinking traces and blockquote artefacts from model responses.

### Force Refresh (`src/tasks/transformers.py`)
- `LLMEnrichmentTask` (and `SummarizationTask` by inheritance) accepts `force_refresh: true` in YAML config — bypasses the `research.json` checkpoint and forces a new LLM call for already-processed items.

### Region Aliasing (`src/tasks/transformers.py`)
- Extended `ALIAS_MAP` in `RegionCategorizationTask` to cover common LLM variants: `"south america"` → `Latin America & Caribbean`, `"asia"` → `East Asia`, `"the americas"` → `North America`, `"unknown"` / `"global"` → `Global`.
- Default fallback changed from `""` to `"Global"` — eliminates false `ManualReviewTask` triggers caused by unrecognised but valid region aliases.

### Fail-Fast Propagation (`src/tasks/transformers.py`, `src/tasks/synthesis.py`)
- Removed silent `try/except` blocks from `BatchLLMTask`, `LLMEnrichmentTask`, and `StrategicSynthesisTask` — errors now surface at the workflow level rather than being swallowed.

## Acceptance Criteria

| Criterion | Status |
|---|---|
| API failure triggers exponential backoff retry | Done |
| Fallback to local Ollama on provider exhaustion | Cancelled — unpredictable in practice |
| `force_refresh: true` overwrites existing summaries | Done |
| "South America" maps to "Latin America & Caribbean" without warning | Done |
