### PR TITLE
27 feature add share button to published briefings

### DIFF
--- a/src/tasks/synthesis.py
+++ b/src/tasks/synthesis.py
@@ -217,3 +217,50 @@ class ReportGenerationTask(PipelineTask):
             raise e
 
         return context
+
+
+@register_task("ShareSummaryTask")
+class ShareSummaryTask(PipelineTask):
+    """
+    Generates a ~100-word share summary from the Global Executive Summary.
+    Stores result as intelligence["Share_Summary"] in the checkpoint.
+    """
+
+    def execute(
+        self, context: WorkflowContext, config: Dict[str, Any]
+    ) -> WorkflowContext:
+        checkpoint_file = self.get_workspace_path(
+            context, config.get("checkpoint_file", "research.json")
+        )
+        prompt_file = config.get("prompt_file")
+        force_refresh = config.get("force_refresh", False)
+
+        artifact = CheckpointManager.load(checkpoint_file)
+        intelligence = artifact.get("intelligence", {})
+
+        if not force_refresh and intelligence.get("Share_Summary"):
+            logger.info("ShareSummaryTask: Share_Summary exists. Skipping LLM call.")
+            return context
+
+        source_text = intelligence.get("Global_Executive_Summary", "")
+        if not source_text:
+            logger.warning(
+                "ShareSummaryTask: Global_Executive_Summary is empty. Skipping."
+            )
+            return context
+
+        with open(prompt_file, encoding="utf-8") as f:
+            prompt_template = f.read()
+
+        prompt = prompt_template.format(content=source_text)
+
+        llm_client = get_llm_client(config)
+        logger.info("ShareSummaryTask: Generating Share_Summary...")
+        result = llm_client.query(prompt, model=config.get("model"))
+
+        intelligence["Share_Summary"] = result
+        artifact["intelligence"] = intelligence
+        CheckpointManager.save(checkpoint_file, artifact)
+
+        logger.info("ShareSummaryTask: Share_Summary saved to checkpoint.")
+        return context

--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -11,8 +11,6 @@ from bs4 import BeautifulSoup
 
 logger = logging.getLogger(__name__)
 
-StealthyFetcher.configure(auto_match=False)
-
 MIN_CONTENT_CHARS = 500  # below this threshold, content is likely a bot-challenge page
 
 _BOT_CHALLENGE_TITLES = (
@@ -33,7 +31,7 @@ def _is_bot_challenge_title(title: str) -> bool:
 def _scrapling_fetch_html(url: str) -> str:
     """Fetch raw HTML via StealthyFetcher (stealth Playwright). Returns empty string on failure."""
     try:
-        fetcher = StealthyFetcher()
+        fetcher = StealthyFetcher(auto_match=False)
         page = fetcher.fetch(url, headless=True, network_idle=True)
         return page.html_content or ""
     except Exception as e:


### PR DESCRIPTION
### Add share button to published briefings

## Summary

- Adds a `ShareSummaryTask` to `src/tasks/synthesis.py` that generates a 100-word plain-text summary with a six-word title from `intelligence["Global_Executive_Summary"]`, saved back to the checkpoint as `intelligence["Share_Summary"]`
- Adds a `generate_share_summary` workflow step to all three pipelines (news, SG, tech), inserted between synthesis and report generation
- Injects a Share button + hidden payload div + inline clipboard JS into all three Jinja2 blog templates; guarded by `{% if intelligence.Share_Summary %}` so it degrades gracefully on older checkpoints
- Adds `<!-- preview-start -->` to SG and tech templates so the share button is excluded from Jekyll post listing previews
- Fixes a pre-existing `StealthyFetcher.configure(auto_match=False)` crash introduced in #26 — `auto_match` is an instance constructor parameter, not a `configure()` argument

## Test plan

- [ ] Run any pipeline with `--resume` against an existing checkpoint — confirm `Share_Summary` appears in the checkpoint JSON after `generate_share_summary` completes
- [ ] Confirm rendered `.md` report contains `id="share-payload"` with summary text and correct post URL
- [ ] Re-run the same pipeline — confirm log shows `Share_Summary exists. Skipping LLM call.`
- [ ] Open published post in browser, click Share, paste into a text editor — verify payload is `[title]\n\n[summary]\n\n[url]` with no markdown formatting
- [ ] Confirm "Copied to clipboard" confirmation appears in light grey and dismisses after 1.5 seconds
- [ ] Confirm share button does not appear in the post preview on the blog homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
