### PR TITLE
Harden web fetcher: swap fetcher priority, raise content threshold, a…

### DIFF
--- a/src/utils/web.py
+++ b/src/utils/web.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 
 logger = logging.getLogger(__name__)
 
-MIN_CONTENT_CHARS = 500  # below this threshold, content is likely a bot-challenge page
+MIN_CONTENT_CHARS = 2000  # below this threshold, content is likely a bot-challenge or cookie-wall page
 
 _BOT_CHALLENGE_TITLES = (
     "just a moment",
@@ -23,7 +23,6 @@ _BOT_CHALLENGE_TITLES = (
     "enable javascript",
 )
 
-
 def _is_bot_challenge_title(title: str) -> bool:
     return any(p in title.lower() for p in _BOT_CHALLENGE_TITLES)
 
@@ -31,8 +30,7 @@ def _is_bot_challenge_title(title: str) -> bool:
 def _scrapling_fetch_html(url: str) -> str:
     """Fetch raw HTML via StealthyFetcher (stealth Playwright). Returns empty string on failure."""
     try:
-        fetcher = StealthyFetcher(auto_match=False)
-        page = fetcher.fetch(url, headless=True, network_idle=True)
+        page = StealthyFetcher.fetch(url, headless=True, network_idle=True)
         return page.html_content or ""
     except Exception as e:
         logger.warning(f"Scrapling fetch failed for {url}: {e}")
@@ -171,60 +169,48 @@ class WebPageExtractor:
 
     def get_webpage_content(self, url: str) -> str:
         """
-        Extracts main content text. Tries Scrapling (stealth Playwright) first;
-        falls back to Selenium if the result is below MIN_CONTENT_CHARS.
+        Extracts main content text. Tries Selenium first;
+        falls back to Scrapling (stealth Playwright) if the result is below MIN_CONTENT_CHARS.
         Raises RuntimeError if both fetchers fail to return sufficient content.
         """
         logger.info(f"Starting content extraction for: {url}")
 
-        # Primary: Scrapling
+        # Primary: Selenium
+        logger.info(f"Selenium primary fetch for content: {url}")
+        self._ensure_page_loaded(url)
+        driver = self.manager.get_driver()
+        content = _parse_content(driver.page_source)
+        if len(content) >= MIN_CONTENT_CHARS:
+            logger.info(f"Selenium extracted {len(content)} chars from {url}")
+            return content
+        logger.warning(
+            f"Selenium returned only {len(content)} chars for {url} "
+            f"(threshold: {MIN_CONTENT_CHARS}) — falling back to Scrapling"
+        )
+
+        # Fallback: Scrapling
+        logger.info(f"Scrapling fallback for content: {url}")
         html = _scrapling_fetch_html(url)
         if html:
             content = _parse_content(html)
             if len(content) >= MIN_CONTENT_CHARS:
                 logger.info(f"Scrapling extracted {len(content)} chars from {url}")
                 return content
-            logger.warning(
-                f"Scrapling returned only {len(content)} chars for {url} "
-                f"(threshold: {MIN_CONTENT_CHARS}) — falling back to Selenium"
-            )
 
-        # Fallback: Selenium
-        logger.info(f"Selenium fallback for content: {url}")
-        self._ensure_page_loaded(url)
-        driver = self.manager.get_driver()
-        content = _parse_content(driver.page_source)
-
-        if len(content) < MIN_CONTENT_CHARS:
-            logger.error(f"Extraction failed. No content found for {url}")
-            raise RuntimeError(f"Failed to extract meaningful content from {url}")
-
-        logger.info(f"Selenium extracted {len(content)} characters from {url}")
-        return content
+        logger.error(f"Extraction failed. No content found for {url}")
+        raise RuntimeError(f"Failed to extract meaningful content from {url}")
 
     def get_webpage_title(self, url: str) -> str:
         """
         Extracts the best possible title (OG Tag > Title Tag > H1).
-        Tries Scrapling first; falls back to Selenium if the result is empty
+        Tries Selenium first; falls back to Scrapling if the result is empty
         or matches a known bot-challenge pattern (e.g. "Just a moment...").
         Raises RuntimeError if no title is found.
         """
         logger.info(f"Starting title extraction for: {url}")
 
-        # Primary: Scrapling
-        html = _scrapling_fetch_html(url)
-        if html:
-            title = _parse_title(html)
-            if title and not _is_bot_challenge_title(title):
-                logger.info(f"Scrapling found title: {title}")
-                return title
-            if title:
-                logger.warning(f"Scrapling returned bot-challenge title '{title}' for {url} — falling back to Selenium")
-            else:
-                logger.warning(f"Scrapling returned no title for {url} — falling back to Selenium")
-
-        # Fallback: Selenium
-        logger.info(f"Selenium fallback for title: {url}")
+        # Primary: Selenium
+        logger.info(f"Selenium primary fetch for title: {url}")
         self._ensure_page_loaded(url)
         driver = self.manager.get_driver()
         soup = BeautifulSoup(driver.page_source, "html.parser")
@@ -232,10 +218,11 @@ class WebPageExtractor:
         og_title = soup.find("meta", property="og:title")
         if og_title and og_title.get("content"):
             title = og_title["content"].strip()
-            logger.info(f"Selenium found OpenGraph title: {title}")
-            return title
+            if title and not _is_bot_challenge_title(title):
+                logger.info(f"Selenium found OpenGraph title: {title}")
+                return title
 
-        if driver.title and driver.title.strip():
+        if driver.title and driver.title.strip() and not _is_bot_challenge_title(driver.title.strip()):
             title = driver.title.strip()
             logger.info(f"Selenium found standard page title: {title}")
             return title
@@ -243,8 +230,20 @@ class WebPageExtractor:
         h1 = soup.find("h1")
         if h1:
             title = h1.get_text(strip=True)
-            logger.info(f"Selenium found H1 title: {title}")
-            return title
+            if title and not _is_bot_challenge_title(title):
+                logger.info(f"Selenium found H1 title: {title}")
+                return title
+
+        logger.warning(f"Selenium returned no valid title for {url} — falling back to Scrapling")
+
+        # Fallback: Scrapling
+        logger.info(f"Scrapling fallback for title: {url}")
+        html = _scrapling_fetch_html(url)
+        if html:
+            title = _parse_title(html)
+            if title and not _is_bot_challenge_title(title):
+                logger.info(f"Scrapling found title: {title}")
+                return title
 
         logger.error(f"Title extraction failed for {url}")
         raise RuntimeError(f"Could not determine title for {url}")

--- a/tests/e2e/test_content_scraper.py
+++ b/tests/e2e/test_content_scraper.py
@@ -1,0 +1,114 @@
+"""
+E2E test for WebPageExtractor.get_webpage_content.
+
+Reads URLs from a CSV with columns: url, expected (pass|fail), reason.
+Runs up to MAX_FETCHES fetches and prints a per-URL report.
+Flags unexpected outcomes (regressions) in the summary.
+
+Usage:
+    python tests/e2e/test_content_scraper.py --csv tests/e2e/inputs/content_urls.csv
+"""
+
+import argparse
+import csv
+import sys
+import time
+import logging
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.utils.web import WebPageExtractor
+
+MAX_FETCHES = 20
+PREVIEW_CHARS = 300
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+
+def load_urls(csv_path: str) -> list[dict]:
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if "url" not in (reader.fieldnames or []):
+            raise ValueError(f"CSV must have a 'url' column. Found: {reader.fieldnames}")
+        rows = []
+        for row in reader:
+            url = row["url"].strip()
+            if not url:
+                continue
+            rows.append({
+                "url": url,
+                "expected": row.get("expected", "pass").strip() or "pass",
+                "reason": row.get("reason", "").strip(),
+            })
+        return rows
+
+
+def verdict(actual_ok: bool, expected: str) -> str:
+    if expected == "fail":
+        return "EXPECTED FAIL" if not actual_ok else "UNEXPECTED PASS"
+    return "OK" if actual_ok else "UNEXPECTED FAIL"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E test: content scraper")
+    parser.add_argument("--csv", required=True, help="Path to CSV with url/expected/reason columns")
+    args = parser.parse_args()
+
+    rows = load_urls(args.csv)
+    total = min(len(rows), MAX_FETCHES)
+    print(f"\nContent scraper — testing {total} URLs from {args.csv}\n")
+
+    extractor = WebPageExtractor()
+    results = []
+
+    try:
+        for i, row in enumerate(rows[:MAX_FETCHES], start=1):
+            url, expected, reason = row["url"], row["expected"], row["reason"]
+            print(f"--- [{i}/{total}] {url} ---")
+            if expected == "fail" and reason:
+                print(f"  EXPECTED : fail ({reason})")
+            t0 = time.time()
+            try:
+                content = extractor.get_webpage_content(url)
+                elapsed = time.time() - t0
+                v = verdict(True, expected)
+                char_count = len(content)
+                preview = content[:PREVIEW_CHARS].replace("\n", " ").strip()
+                truncated = len(content) > PREVIEW_CHARS
+                print(f"  STATUS   : {v} ({elapsed:.1f}s)")
+                print(f"  CHARS    : {char_count}")
+                print(f"  PREVIEW  : {preview}", end="")
+                print(" [truncated]" if truncated else "")
+                results.append((url, v))
+            except Exception as e:
+                elapsed = time.time() - t0
+                v = verdict(False, expected)
+                print(f"  STATUS   : {v} ({elapsed:.1f}s)")
+                print(f"  ERROR    : {e}")
+                results.append((url, v))
+            print()
+    finally:
+        extractor.manager.quit_driver()
+
+    regressions = [r for r in results if "UNEXPECTED" in r[1]]
+    print(f"{'=' * 60}")
+    print(f"SUMMARY: {total} URLs")
+    counts = {}
+    for _, v in results:
+        counts[v] = counts.get(v, 0) + 1
+    for v, n in sorted(counts.items()):
+        print(f"  {v:<20} {n}")
+    if regressions:
+        print(f"\nREGRESSIONS ({len(regressions)}):")
+        for url, v in regressions:
+            print(f"  {v}: {url}")
+    print(f"{'=' * 60}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/test_title_scraper.py
+++ b/tests/e2e/test_title_scraper.py
@@ -1,0 +1,112 @@
+"""
+E2E test for WebPageExtractor.get_webpage_title.
+
+Reads URLs from a CSV with columns: url, expected (pass|fail), reason.
+Runs up to MAX_FETCHES fetches and prints a per-URL report.
+Flags unexpected outcomes (regressions) in the summary.
+
+Usage:
+    python tests/e2e/test_title_scraper.py --csv tests/e2e/inputs/title_urls.csv
+"""
+
+import argparse
+import csv
+import sys
+import time
+import logging
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from src.utils.web import WebPageExtractor
+
+MAX_FETCHES = 20
+MIN_TITLE_CHARS = 5  # titles shorter than this are likely garbage (e.g. "404", "...")
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s — %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+
+def load_urls(csv_path: str) -> list[dict]:
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if "url" not in (reader.fieldnames or []):
+            raise ValueError(f"CSV must have a 'url' column. Found: {reader.fieldnames}")
+        rows = []
+        for row in reader:
+            url = row["url"].strip()
+            if not url:
+                continue
+            rows.append({
+                "url": url,
+                "expected": row.get("expected", "pass").strip() or "pass",
+                "reason": row.get("reason", "").strip(),
+            })
+        return rows
+
+
+def verdict(actual_ok: bool, expected: str) -> str:
+    if expected == "fail":
+        return "EXPECTED FAIL" if not actual_ok else "UNEXPECTED PASS"
+    return "OK" if actual_ok else "UNEXPECTED FAIL"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E test: title scraper")
+    parser.add_argument("--csv", required=True, help="Path to CSV with url/expected/reason columns")
+    args = parser.parse_args()
+
+    rows = load_urls(args.csv)
+    total = min(len(rows), MAX_FETCHES)
+    print(f"\nTitle scraper — testing {total} URLs from {args.csv}\n")
+
+    extractor = WebPageExtractor()
+    results = []
+
+    try:
+        for i, row in enumerate(rows[:MAX_FETCHES], start=1):
+            url, expected, reason = row["url"], row["expected"], row["reason"]
+            print(f"--- [{i}/{total}] {url} ---")
+            if expected == "fail" and reason:
+                print(f"  EXPECTED : fail ({reason})")
+            t0 = time.time()
+            try:
+                title = extractor.get_webpage_title(url)
+                elapsed = time.time() - t0
+                actual_ok = bool(title) and len(title) >= MIN_TITLE_CHARS
+                v = verdict(actual_ok, expected)
+                print(f"  STATUS   : {v} ({elapsed:.1f}s)")
+                print(f"  TITLE    : {title!r} ({len(title)} chars)")
+                if not actual_ok:
+                    print(f"  NOTE     : title too short (min {MIN_TITLE_CHARS} chars)")
+                results.append((url, v))
+            except Exception as e:
+                elapsed = time.time() - t0
+                v = verdict(False, expected)
+                print(f"  STATUS   : {v} ({elapsed:.1f}s)")
+                print(f"  ERROR    : {e}")
+                results.append((url, v))
+            print()
+    finally:
+        extractor.manager.quit_driver()
+
+    regressions = [r for r in results if "UNEXPECTED" in r[1]]
+    print(f"{'=' * 60}")
+    print(f"SUMMARY: {total} URLs")
+    counts = {}
+    for _, v in results:
+        counts[v] = counts.get(v, 0) + 1
+    for v, n in sorted(counts.items()):
+        print(f"  {v:<20} {n}")
+    if regressions:
+        print(f"\nREGRESSIONS ({len(regressions)}):")
+        for url, v in regressions:
+            print(f"  {v}: {url}")
+    print(f"{'=' * 60}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

# PR — Harden web fetcher + add E2E test suite

## Changes

### `src/utils/web.py`

- **Swapped fetcher order** in `get_webpage_content` and `get_webpage_title`: Selenium is now primary, Scrapling is the fallback
- **Raised `MIN_CONTENT_CHARS`** from 500 → 2000 to filter out cookie walls and bot-challenge pages
- **Added bot-challenge checks to `get_webpage_title`** Selenium path: OG tag, page title, and H1 are each validated against `_is_bot_challenge_title` before returning, consistent with how the Scrapling path already worked
- **Simplified `_scrapling_fetch_html`**: switched to the class-level `StealthyFetcher.fetch()` call per current Scrapling docs

### `tests/e2e/`

First tests in this repo — an E2E suite for the web fetcher.

- `test_title_scraper.py` — runs `get_webpage_title` over a CSV of URLs; fails titles that are empty or below `MIN_TITLE_CHARS`
- `test_content_scraper.py` — runs `get_webpage_content` over a CSV of URLs; prints char count and content preview
- `inputs/title_urls.csv` / `inputs/content_urls.csv` — 20 URLs each with `expected` (pass|fail) and `reason` columns

Known failure modes are first-class test cases, not noise. The summary flags `UNEXPECTED FAIL` and `UNEXPECTED PASS` as regressions.

**Run:**
```bash
python tests/e2e/run_all.py \
  --title-csv tests/e2e/inputs/title_urls.csv \
  --content-csv tests/e2e/inputs/content_urls.csv
```

## Test results (pre-merge baseline)

| Test | URLs | OK | Expected fail | Unexpected |
|---|---|---|---|---|
| Title scraper | 20 | 20 | 0 | 0 |
| Content scraper | 20 | 18 | 2 | 0 |

Known expected failures:
- `reuters.com` — `paywall_block` (401 on both fetchers)
- `france24.com` — `cookie_wall` (GDPR consent page, ~1900 chars, below new 2000-char threshold)
