### PR TITLE
chore: mark research pipeline tasks as deprecated

### DIFF
--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -13,12 +13,12 @@ import src.tasks.transformers  # noqa: F401
 import src.tasks.aggregators  # noqa: F401
 import src.tasks.writers  # noqa: F401
 import src.tasks.splitters  # noqa: F401
-import src.tasks.extractors  # noqa: F401
+import src.tasks.extractors  # noqa: F401  # DEPRECATED: migrated to research-engine
 import src.tasks.utilities  # noqa: F401
 import src.tasks.notifications  # noqa: F401
-import src.tasks.synthesis  # noqa: F401
-import src.tasks.delivery  # noqa: F401
-import src.tasks.audit  # noqa: F401
+import src.tasks.synthesis  # noqa: F401  # DEPRECATED: migrated to research-engine
+import src.tasks.delivery  # noqa: F401  # DEPRECATED: migrated to research-engine
+import src.tasks.audit  # noqa: F401  # DEPRECATED: migrated to research-engine
 
 logger = logging.getLogger(__name__)
 

--- a/src/tasks/audit.py
+++ b/src/tasks/audit.py
@@ -131,7 +131,7 @@ def _build_section_e(combined_sections: str, audit_report_prompt_file: str, conf
 
 
 @register_task("PipelineAuditTask")
-class PipelineAuditTask(PipelineTask):
+class PipelineAuditTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     def execute(self, context: WorkflowContext, config: Dict[str, Any]) -> WorkflowContext:
         checkpoint_file = config.get("checkpoint_file")
         target_key = config.get("target_key", "research_data")

--- a/src/tasks/delivery.py
+++ b/src/tasks/delivery.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @register_task("CloudArchivalTask")
-class CloudArchivalTask(PipelineTask):
+class CloudArchivalTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Zips the current workspace and uploads it to an S3 bucket.
     """
@@ -66,7 +66,7 @@ class CloudArchivalTask(PipelineTask):
 
 
 @register_task("GitPublisherTask")
-class GitPublisherTask(PipelineTask):
+class GitPublisherTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Copies the generated report to a local repository, commits, and pushes it.
     """

--- a/src/tasks/extractors.py
+++ b/src/tasks/extractors.py
@@ -89,7 +89,7 @@ class UniversalExtractorTask(PipelineTask):
 
 
 @register_task("ManualReviewTask")
-class ManualReviewTask(PipelineTask):
+class ManualReviewTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Human-in-the-Loop (HITL) Review.
     1. Pre-scans all items to identify those with missing fields.
@@ -220,7 +220,7 @@ class ManualReviewTask(PipelineTask):
 
 
 @register_task("SourceGatheringTask")
-class SourceGatheringTask(PipelineTask):
+class SourceGatheringTask(PipelineTask):  # DEPRECATED: migrated to research-engine
 
     """
     Constructs the 'To-Do' list for the research pipeline.
@@ -372,7 +372,7 @@ class SourceGatheringTask(PipelineTask):
 
 
 @register_task("ContentScrapingTask")
-class ContentScrapingTask(PipelineTask):
+class ContentScrapingTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Source Content Scraper.
     Orchestrates extraction logic based on source type/format.
@@ -525,7 +525,7 @@ class ContentScrapingTask(PipelineTask):
 
 
 @register_task("TitleScrapingTask")
-class TitleScrapingTask(PipelineTask):
+class TitleScrapingTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Enriches items with titles.
     """

--- a/src/tasks/loaders.py
+++ b/src/tasks/loaders.py
@@ -112,7 +112,7 @@ class DirectoryLoader(PipelineTask):
 
 
 @register_task("SourceCSVLoader")
-class SourceCSVLoader(PipelineTask):
+class SourceCSVLoader(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Loads a sources.csv into the Context.
     Schema: id, name, url, type, rank, tags, format

--- a/src/tasks/synthesis.py
+++ b/src/tasks/synthesis.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 @register_task("StrategicSynthesisTask")
-class StrategicSynthesisTask(PipelineTask):
+class StrategicSynthesisTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Aggregates all intel and generates:
     1. Global Executive Summary.
@@ -147,7 +147,7 @@ class StrategicSynthesisTask(PipelineTask):
 
 
 @register_task("ReportGenerationTask")
-class ReportGenerationTask(PipelineTask):
+class ReportGenerationTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Renders the final Markdown report using Jinja2.
     """
@@ -220,7 +220,7 @@ class ReportGenerationTask(PipelineTask):
 
 
 @register_task("ShareSummaryTask")
-class ShareSummaryTask(PipelineTask):
+class ShareSummaryTask(PipelineTask):  # DEPRECATED: migrated to research-engine
     """
     Generates a ~100-word share summary from the Global Executive Summary.
     Stores result as intelligence["Share_Summary"] in the checkpoint.

--- a/src/tasks/transformers.py
+++ b/src/tasks/transformers.py
@@ -373,7 +373,7 @@ class LLMEnrichmentTask(PipelineTask):
 
 
 @register_task("RegionCategorizationTask")
-class RegionCategorizationTask(LLMEnrichmentTask):
+class RegionCategorizationTask(LLMEnrichmentTask):  # DEPRECATED: migrated to research-engine
     """
     Specific implementation for Region Categorization.
     """
@@ -446,7 +446,7 @@ class RegionCategorizationTask(LLMEnrichmentTask):
 
 
 @register_task("SummarizationTask")
-class SummarizationTask(LLMEnrichmentTask):
+class SummarizationTask(LLMEnrichmentTask):  # DEPRECATED: migrated to research-engine
     """
     Specific implementation for Content Summarization.
     """


### PR DESCRIPTION
## Context

The three research/publishing workflows (`sg_research_pipeline`, `tech_research_pipeline`, `news_research_pipeline`) have been extracted into a new standalone repo: [`research-engine`](https://github.com/GD-MRNG/research-engine) (see PR GD-MRNG/research-engine#2).

These workflows were the only consumers of a distinct set of task classes in this repo — the web scraping, synthesis, delivery, and audit stack. All other workflows here are document-processing pipelines that use a completely different set of tasks and are unaffected by this change.

This PR does **not** delete anything. It marks the migrated classes with `# DEPRECATED: migrated to research-engine` so they are easy to identify during the cleanup pass once `research-engine` is validated end-to-end.

## What's marked

**`src/core/engine.py`** — import lines for modules that are now exclusively research-pipeline-serving:
- `src.tasks.extractors`
- `src.tasks.synthesis`
- `src.tasks.delivery`
- `src.tasks.audit`

**`src/tasks/loaders.py`**
- `SourceCSVLoader`

**`src/tasks/extractors.py`**
- `SourceGatheringTask`
- `ContentScrapingTask`
- `TitleScrapingTask`
- `ManualReviewTask`

**`src/tasks/transformers.py`**
- `SummarizationTask`
- `RegionCategorizationTask`

**`src/tasks/synthesis.py`**
- `StrategicSynthesisTask`
- `ReportGenerationTask`
- `ShareSummaryTask`

**`src/tasks/delivery.py`**
- `CloudArchivalTask`
- `GitPublisherTask`

**`src/tasks/audit.py`**
- `PipelineAuditTask`

**Not marked:** `NotificationTask` — it is shared with non-research workflows in this repo and stays.

## What's unaffected

All 12 document-processing workflows and their task classes are untouched. The engine continues to load and run them as before.

## Cleanup pass (follow-up — not this PR)

Once `research-engine` is confirmed working:
1. Delete the deprecated classes from the files above
2. Remove their `@register_task` registrations and the flagged engine imports
3. Smoke-test remaining workflows with `provider: "mock"` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)